### PR TITLE
Handle dates as columns instead of df index

### DIFF
--- a/scripts/raw_to_processed.py
+++ b/scripts/raw_to_processed.py
@@ -55,15 +55,13 @@ rampart_combined = rampart_combined.groupby('date').mean()
 rampart_combined.reset_index(level=0, inplace=True)
 
 # add 'siteid', 'year', and 'adjusted count' columns
-eagle_combined['siteid'] = lookup_table.loc['Eagle Peak A 2011 RAW.csv']
-['siteid']
+eagle_combined['siteid'] = lookup_table.loc['Eagle Peak A 2011 RAW.csv']['siteid']
 eagle_combined['adjusted_people_count'] = (eagle_combined['people_count'] *
                                            (lookup_table.loc['Eagle Peak '
                                             'A 2011 RAW.csv']
                                             ['adjustment_factor'])) / 2
 
-rampart_combined['siteid'] = lookup_table.loc['Rampart Ridge A 2011 RAW.csv']
-['siteid']
+rampart_combined['siteid'] = lookup_table.loc['Rampart Ridge A 2011 RAW.csv']['siteid']
 rampart_combined['adjusted_people_count'] = (rampart_combined['people_count'] *
                                              (lookup_table.loc['Rampart Ridge '
                                               'A 2011 RAW.csv']
@@ -78,8 +76,9 @@ raw_concat = pd.DataFrame([])
 
 # loop for pulling raw count files, adding specific columns and
 # adding to larger spreadsheet
-for filepath in glob.glob('data/raw/*.{}'.format('csv')):
+for filepath in glob.glob('../data/raw/*.{}'.format('csv')):
 
+    print(filepath)
     # use filename to read csv into 'temp variable'
     temp = pd.read_csv(filepath, names=['date', 'people_count'])
 

--- a/scripts/raw_to_processed.py
+++ b/scripts/raw_to_processed.py
@@ -10,22 +10,22 @@ import os
 import pandas as pd
 
 #  import 'lookup_table' and set index
-lookup_table = pd.read_csv('tables/lookup_table.csv')
+lookup_table = pd.read_csv('../tables/lookup_table.csv')
 lookup_table = lookup_table.set_index('loc')
 
 #  import exclusion.csv
-exclusion_table = pd.read_csv('tables/exclusion.csv', encoding='utf8')
+exclusion_table = pd.read_csv('../tables/exclusion.csv', encoding='utf8')
 exclusion_table['start'] = pd.to_datetime(exclusion_table['start'])
 exclusion_table['stop'] = pd.to_datetime(exclusion_table['stop'])
 
 #  process those two sites that had A and B counts for the same year
-eagle_a = pd.read_csv('data/raw_A_B_duplicates/Eagle Peak A 2011 RAW.csv',
+eagle_a = pd.read_csv('../data/raw_A_B_duplicates/Eagle Peak A 2011 RAW.csv',
                       names=['date', 'people_count'])
-eagle_b = pd.read_csv('data/raw_A_B_duplicates/Eagle Peak A 2011 RAW.csv',
+eagle_b = pd.read_csv('../data/raw_A_B_duplicates/Eagle Peak A 2011 RAW.csv',
                       names=['date', 'people_count'])
-rampart_a = pd.read_csv('data/raw_A_B_duplicates/Rampart Ridge A 2011 RAW.csv',
+rampart_a = pd.read_csv('../data/raw_A_B_duplicates/Rampart Ridge A 2011 RAW.csv',
                       names=['date', 'people_count'])
-rampart_b = pd.read_csv('data/raw_A_B_duplicates/Rampart Ridge B 2011 RAW.csv',
+rampart_b = pd.read_csv('../data/raw_A_B_duplicates/Rampart Ridge B 2011 RAW.csv',
                       names=['date', 'people_count'])
 
 eagle_a['date'] = pd.to_datetime(eagle_a['date'])
@@ -155,7 +155,7 @@ raw_concat_final_exclusion = raw_concat_final_exclusion.append(to_append,
                                                                =False)
 
 # export daily counts
-raw_concat_final_exclusion.to_csv('data/processed/day_counts.csv', index=False)
+raw_concat_final_exclusion.to_csv('../data/processed/day_counts.csv', index=False)
 
 # declaring df for appending in line 179
 weekly = pd.DataFrame([])
@@ -223,4 +223,4 @@ weekly = weekly.drop(columns=['daycount'])
 weekly.reset_index(level=0, inplace=True)
 
 # export
-weekly.to_csv('data/processed/weekly_counts.csv', index=False)
+weekly.to_csv('../data/processed/weekly_counts.csv', index=False)


### PR DESCRIPTION
Simplify table subsetting by working directly with date columns
instead of subsetting by date as the table index